### PR TITLE
New server config fix #8

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,2 @@
 [lfs]
-    url = "http://lfs:lfs123@172.16.3.136:8080/repository/gitlfs-hosted/info/lfs"
+    url = "http://lfs:lfs@10.32.0.112:8080/repository/gitlfs-hosted/info/lfs"

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,2 @@
 [lfs]
-    url = "http://lfs:lfs@10.32.0.112:8080/repository/gitlfs-hosted/info/lfs"
+    url = "http://lfs:lfs@10.32.0.112:8080/repository/twgo-lfs/info/lfs"


### PR DESCRIPTION
```
lfs@twgo-lfs:~/pian7sik4_gi2liau7$ git lfs push origin new_server --all
Uploading LFS objects: 100% (126163/126163), 9.1 GB | 4.2 MB/s, done
```
一波三折。新server 語料已傳完畢

因為新的語料數量超過server http post限制

碰到 too many open files 問題

還好google有解，mis真是多眉角，感謝google 老師 XD

https://github.com/twgo/pian7sik4_gi2liau7/wiki/SOLVE---git-lfs-push-issue-%22too-many-open-files%22